### PR TITLE
Schedule run of github licensing bot.

### DIFF
--- a/.github/workflows/github-licensing-bot.yml
+++ b/.github/workflows/github-licensing-bot.yml
@@ -1,7 +1,8 @@
 name: run-github-licensing-bot
 
 on:
-  - workflow_dispatch
+  schedule:
+    - cron: "0 10 */2 * *"
 
 env:
   IMAGE_NAME: github-licensing-bot


### PR DESCRIPTION
Fixes #8 

Bot will run at 10AM every 2 days.